### PR TITLE
Hide sessionStorage warnings in production

### DIFF
--- a/packages/gatsby-react-router-scroll/src/StateStorage.js
+++ b/packages/gatsby-react-router-scroll/src/StateStorage.js
@@ -9,9 +9,11 @@ export default class SessionStorage {
       const value = window.sessionStorage.getItem(stateKey)
       return JSON.parse(value)
     } catch (e) {
-      console.warn(
-        `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
-      )
+      if (__DEV__) {
+        console.warn(
+          `[gatsby-react-router-scroll] Unable to access sessionStorage; sessionStorage is not available.`
+        )
+      }
 
       if (
         window &&
@@ -39,9 +41,11 @@ export default class SessionStorage {
         window[GATSBY_ROUTER_SCROLL_STATE][stateKey] = JSON.parse(storedValue)
       }
 
-      console.warn(
-        `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
-      )
+      if (__DEV__) {
+        console.warn(
+          `[gatsby-react-router-scroll] Unable to save state in sessionStorage; sessionStorage is not available.`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
## Description

If cookies are disabled, the production version of the website would show console warnings when scrolling.

With this change, those warnigns will only be visible in the development version.

## Related Issues

Fixes #12577